### PR TITLE
using token

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,7 +96,9 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/actinia-core-${{ matrix.flavor }}/Dockerfile
-
+          secrets: |
+              "GITHUB_TOKEN=${{ secrets.TOKEN_GITHUB }}"
+              "GITHUB_USERNAME=${{ secrets.USERNAME_GITHUB }}"
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
@@ -135,6 +137,9 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/actinia-core-alpine/Dockerfile
+          secrets: |
+              "GITHUB_TOKEN=${{ secrets.TOKEN_GITHUB }}"
+              "GITHUB_USERNAME=${{ secrets.USERNAME_GITHUB }}"
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
@@ -178,6 +183,9 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/actinia-core-alpine/Dockerfile
+          secrets: |
+              "GITHUB_TOKEN=${{ secrets.TOKEN_GITHUB }}"
+              "GITHUB_USERNAME=${{ secrets.USERNAME_GITHUB }}"
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
@@ -222,5 +230,8 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/actinia-core-alpine/Dockerfile
+          secrets: |
+              "GITHUB_TOKEN=${{ secrets.TOKEN_GITHUB }}"
+              "GITHUB_USERNAME=${{ secrets.USERNAME_GITHUB }}"
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main,GHA_dockerfile]
     tags: ['*.*.*']
     paths-ignore: ['docs/**']
   release:

--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -60,27 +60,39 @@ RUN while IFS=, read -r ADDON SERVER; do unset URL; test -z $SERVER || URL="url=
 # ADD https://api.github.com/repos/mundialis/actinia_statistic_plugin/releases/latest /scratch/actinia_statistic_plugin_latest_release.json
 WORKDIR /build
 # Get statistics plugin (53929318 = 0.0.4)
-RUN curl https://api.github.com/repos/mundialis/actinia_statistic_plugin/releases/53929318 > resp.json && \
+RUN --mount=type=secret,id=GITHUB_USERNAME \
+  --mount=type=secret,id=GITHUB_TOKEN \
+  curl -u `cat /run/secrets/GITHUB_USERNAME`:`cat /run/secrets/GITHUB_TOKEN` https://api.github.com/repos/mundialis/actinia_statistic_plugin/releases/53929318 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
 # Get satellite plugin (53929219 = 0.0.4)
-RUN curl https://api.github.com/repos/mundialis/actinia_satellite_plugin/releases/53929219 > resp.json && \
+RUN --mount=type=secret,id=GITHUB_USERNAME \
+  --mount=type=secret,id=GITHUB_TOKEN \
+  curl -u `cat /run/secrets/GITHUB_USERNAME`:`cat /run/secrets/GITHUB_TOKEN` https://api.github.com/repos/mundialis/actinia_satellite_plugin/releases/53929219 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
 # Get actinia-metadata-plugin (53929141 = 1.0.2)
-RUN curl https://api.github.com/repos/mundialis/actinia-metadata-plugin/releases/53929141 > resp.json && \
+RUN --mount=type=secret,id=GITHUB_USERNAME \
+  --mount=type=secret,id=GITHUB_TOKEN \
+  curl -u `cat /run/secrets/GITHUB_USERNAME`:`cat /run/secrets/GITHUB_TOKEN` https://api.github.com/repos/mundialis/actinia-metadata-plugin/releases/53929141 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
 # Get actinia-module-plugin (55823847 = 2.2.4)
-RUN curl https://api.github.com/repos/mundialis/actinia-module-plugin/releases/55823847 > resp.json && \
+RUN --mount=type=secret,id=GITHUB_USERNAME \
+  --mount=type=secret,id=GITHUB_TOKEN \
+  curl -u `cat /run/secrets/GITHUB_USERNAME`:`cat /run/secrets/GITHUB_TOKEN` https://api.github.com/repos/mundialis/actinia-module-plugin/releases/55823847 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
 # Get actinia-stac-plugin (54012264 = 0.0.1)
-RUN curl https://api.github.com/repos/mundialis/actinia-stac-plugin/releases/54012264 > resp.json && \
+RUN --mount=type=secret,id=GITHUB_USERNAME \
+  --mount=type=secret,id=GITHUB_TOKEN \
+  curl -u `cat /run/secrets/GITHUB_USERNAME`:`cat /run/secrets/GITHUB_TOKEN` https://api.github.com/repos/mundialis/actinia-stac-plugin/releases/54012264 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
 # Get actinia-api (56998472 = 3.0.1)
-RUN curl https://api.github.com/repos/mundialis/actinia-api/releases/56998472 > resp.json && \
+RUN --mount=type=secret,id=GITHUB_USERNAME \
+  --mount=type=secret,id=GITHUB_TOKEN \
+  curl -u `cat /run/secrets/GITHUB_USERNAME`:`cat /run/secrets/GITHUB_TOKEN` https://api.github.com/repos/mundialis/actinia-api/releases/56998472 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
 

--- a/docker/actinia-core-alpine/README.md
+++ b/docker/actinia-core-alpine/README.md
@@ -25,10 +25,14 @@ $ docker build \
 $ docker tag actinia-core:alpine-runtime-pkgs mundialis/actinia-core:alpine-runtime-pkgs_v9
 $ docker push mundialis/actinia-core:alpine-runtime-pkgs_v9
 
-$ docker build \
+$ DOCKER_BUILDKIT=1 docker build \
+        --progress=plain \
         --pull \
         --no-cache \
         --file docker/actinia-core-alpine/Dockerfile \
-        --tag actinia-core:g78-stable-alpine .
+        --tag actinia-core:g78-stable-alpine \
+        --secret id=GITHUB_TOKEN,src=secret_t.txt \
+        --secret id=GITHUB_USERNAME,src=secret_u.txt \
+        .
 
 ```


### PR DESCRIPTION
The build often fails because of the limited github `rate_limit`. Using a github token should avoid this.